### PR TITLE
Release 1.0.0

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -52,10 +52,10 @@ The following table provides version and version-support information about the D
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v0.9.6</td>
+        <td>v1.0.0</td>
     <tr>
         <td>Release date</td>
-        <td>November 5, 2018</td>
+        <td>November 15, 2018</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -5,6 +5,14 @@ owner: Partners
 
 These are release notes for Datadog Application Monitoring for Pivotal Cloud Foundry (PCF).
 
+##<a id="ver"></a> 1.0.0
+
+**Release Date:** November 5, 2018
+
+Feature included in this release:
+
+* The logs agent is officially out of beta on Cloud Foundry. The API has changed significantly, new instructions are available in the [readme](https://github.com/DataDog/datadog-cloudfoundry-buildpack#log-collection-beta---no-official-release-yet) and in the [documentation](https://docs.datadoghq.com/integrations/cloud_foundry/#monitor-your-applications-on-cloud-foundry).
+
 ##<a id="ver"></a> v0.9.6
 
 **Release Date:** November 5, 2018


### PR DESCRIPTION
This adds information about release 1.0.0.

Logs collection is now officially out of beta