### PR TITLE
Update docs for 1.11.0 release

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -50,22 +50,22 @@ The following table provides version and version-support information about the D
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>1.10.0</td>
+        <td>1.11.0</td>
     <tr>
         <td>Release date</td>
-        <td>November 6, 2019</td>
+        <td>January 8, 2020</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>6.15.0</td>
+        <td>7.16.0</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x and 2.7.x</td>
+        <td>2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, and 2.8.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
-        <td>2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x and 2.7.x</td>
+        <td>2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, and 2.8.x</td>
     </tr>
     <tr>
         <td>BOSH stemcell version</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -5,6 +5,18 @@ owner: Partners
 
 These are release notes for Datadog Application Monitoring for Pivotal Platform.
 
+##<a id="ver"></a> 1.11.0
+
+**Release Date:** January 8, 2020
+
+Feature included in this release:
+
+* Upgrades the agent to 7.16.0. For more information, see the
+[datadog-agent 7.16.0](https://github.com/DataDog/datadog-agent/releases/tag/7.16.0) release in GitHub.
+* Standardize the environment variable naming for HTTP Proxy in log validation script,
+add DD_SKIP_LOGS_TEST variable to allow bypassing of log validation script, and strip the protocol on
+the provided proxy before passing to nc command. See [#70](https://github.com/DataDog/datadog-cloudfoundry-buildpack/pull/70)
+
 ##<a id="ver"></a> 1.10.0
 
 **Release Date:** November 6, 2019


### PR DESCRIPTION
Update release documentation for the 1.11.0 release 
https://github.com/DataDog/datadog-application-monitoring-pivotal-tile/releases/tag/v1.11.0
Note this updates our support to 2.8.x 