### PR TITLE
Update the docs for the 1.12.0 release

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -50,14 +50,14 @@ The following table provides version and version-support information about the D
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>1.11.0</td>
+        <td>1.12.0</td>
     <tr>
         <td>Release date</td>
-        <td>January 8, 2020</td>
+        <td>February 13, 2020</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>7.16.0</td>
+        <td>7.17.0</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -5,6 +5,16 @@ owner: Partners
 
 These are release notes for Datadog Application Monitoring for Pivotal Platform.
 
+##<a id="ver"></a> 1.12.0
+
+**Release Date:** February 13, 2020
+
+Feature included in this release:
+
+* Upgrades the agent to 7.17.0. For more information, see the
+[datadog-agent 7.17.0](https://github.com/DataDog/datadog-agent/releases/tag/7.17.0) release in GitHub.
+* Add the Agent template files so the status command can be run within the buildpack. See [#74](https://github.com/DataDog/datadog-cloudfoundry-buildpack/pull/74)
+
 ##<a id="ver"></a> 1.11.0
 
 **Release Date:** January 8, 2020


### PR DESCRIPTION
Update documentation for the 1.12.0 release of the datadog application monitoring tile